### PR TITLE
[windows] use modern cpp & more portable fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,12 +5,15 @@ if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
-find_package(catkin REQUIRED)
+find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(Eigen3 REQUIRED)
+find_package(suitesparse QUIET)
+if(NOT SuiteSparse_FOUND)
+  set(SuiteSparse_LIBRARIES blas lapack cholmod cxsparse)
+endif()
 
-include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${SuiteSparse_INCLUDE_DIRS})
 add_definitions(${EIGEN3_DEFINITIONS})
-
 INCLUDE_DIRECTORIES(include)
 
 catkin_package(
@@ -23,7 +26,7 @@ add_definitions(-DSBA_CHOLMOD)
 # SBA library
 add_library(sba src/sba.cpp src/spa.cpp src/spa2d.cpp src/csparse.cpp src/proj.cpp src/node.cpp src/sba_file_io.cpp)
 #rosbuild_add_compile_flags(sba ${SSE_FLAGS})
-target_link_libraries(sba blas lapack cholmod cxsparse)
+target_link_libraries(sba ${SuiteSparse_LIBRARIES})
 
 install(DIRECTORY include/sparse_bundle_adjustment/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/include/sparse_bundle_adjustment/sba_setup.h
+++ b/include/sparse_bundle_adjustment/sba_setup.h
@@ -48,7 +48,6 @@ using namespace frame_common;
 #include <iostream>
 #include <fstream>
 #include <vector>
-#include <sys/time.h>
 
 using namespace std;
 

--- a/package.xml
+++ b/package.xml
@@ -9,6 +9,7 @@
 
   <buildtool_depend>catkin</buildtool_depend>
 
+  <depend>roscpp</depend>
   <depend>eigen</depend>
   <depend>liblapack-dev</depend>
   <depend>libblas-dev</depend>

--- a/src/csparse.cpp
+++ b/src/csparse.cpp
@@ -44,7 +44,6 @@ using namespace Eigen;
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <sys/time.h>
 #include <algorithm>
 
 using namespace std;

--- a/src/sba.cpp
+++ b/src/sba.cpp
@@ -37,6 +37,7 @@
 //
 
 #include "sparse_bundle_adjustment/sba.h"
+#include <chrono>
 
 using namespace Eigen;
 using namespace std;
@@ -44,15 +45,10 @@ using namespace std;
 //#define DEBUG
 
 // elapsed time in microseconds
-#include <sys/time.h>
 static long long utime()
 {
-  timeval tv;
-  gettimeofday(&tv,NULL);
-  long long ts = tv.tv_sec;
-  ts *= 1000000;
-  ts += tv.tv_usec;
-  return ts;
+  auto duration = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
 

--- a/src/spa.cpp
+++ b/src/spa.cpp
@@ -52,6 +52,7 @@
 #include <stdio.h>
 #include "sparse_bundle_adjustment/sba.h"
 #include <Eigen/Cholesky>
+#include <chrono>
 
 using namespace Eigen;
 using namespace std;
@@ -59,18 +60,13 @@ using namespace std;
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <sys/time.h>
 #include <utility>
 
 // elapsed time in microseconds
 static long long utime()
 {
-  timeval tv;
-  gettimeofday(&tv,nullptr);
-  long long ts = tv.tv_sec;
-  ts *= 1000000;
-  ts += tv.tv_usec;
-  return ts;
+  auto duration = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
 namespace sba

--- a/src/spa2d.cpp
+++ b/src/spa2d.cpp
@@ -39,6 +39,7 @@
 #include <stdio.h>
 #include "sparse_bundle_adjustment/spa2d.h"
 #include <Eigen/Cholesky>
+#include <chrono>
 
 using namespace Eigen;
 using namespace std;
@@ -46,17 +47,12 @@ using namespace std;
 #include <iostream>
 #include <iomanip>
 #include <fstream>
-#include <sys/time.h>
 
 // elapsed time in microseconds
 static long long utime()
 {
-  timeval tv;
-  gettimeofday(&tv,NULL);
-  long long ts = tv.tv_sec;
-  ts *= 1000000;
-  ts += tv.tv_usec;
-  return ts;
+  auto duration = std::chrono::system_clock::now().time_since_epoch();
+  return std::chrono::duration_cast<std::chrono::microseconds>(duration).count();
 }
 
 namespace sba


### PR DESCRIPTION
This pull request is motivated by enabling this package for https://aka.ms/ros project.

* To be explicit about `roscpp` dependency, so the `catkin` can add the required include paths.
* Replace `gettimeofday` with `C++11` implementation.
* Discover `suitesparse` by `find_package` when possible, which makes the build recipes more portable.