### PR TITLE
Steps toward compilation on OSX

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,18 +1,18 @@
 cmake_minimum_required(VERSION 3.1)
 project(sparse_bundle_adjustment)
 
+list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_LIST_DIR}/cmake)
+
 if(NOT CMAKE_CXX_STANDARD)
   set(CMAKE_CXX_STANDARD 11)
 endif()
 
 find_package(catkin REQUIRED COMPONENTS roscpp)
 find_package(Eigen3 REQUIRED)
-find_package(suitesparse QUIET)
-if(NOT SuiteSparse_FOUND)
-  set(SuiteSparse_LIBRARIES blas lapack cholmod cxsparse)
-endif()
+find_package(SuiteSparse REQUIRED)
+find_package(CXSparse)
 
-include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${SuiteSparse_INCLUDE_DIRS})
+include_directories(${catkin_INCLUDE_DIRS} ${EIGEN3_INCLUDE_DIRS} ${SUITESPARSE_INCLUDE_DIRS} ${CXSPARSE_INCLUDE_DIRS})
 add_definitions(${EIGEN3_DEFINITIONS})
 INCLUDE_DIRECTORIES(include)
 
@@ -26,7 +26,7 @@ add_definitions(-DSBA_CHOLMOD)
 # SBA library
 add_library(sba src/sba.cpp src/spa.cpp src/spa2d.cpp src/csparse.cpp src/proj.cpp src/node.cpp src/sba_file_io.cpp)
 #rosbuild_add_compile_flags(sba ${SSE_FLAGS})
-target_link_libraries(sba ${SuiteSparse_LIBRARIES})
+target_link_libraries(sba ${SUITESPARSE_LIBRARIES} ${CXSPARSE_LIBRARIES})
 
 install(DIRECTORY include/sparse_bundle_adjustment/
         DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION})

--- a/cmake/FindCXSparse.cmake
+++ b/cmake/FindCXSparse.cmake
@@ -1,0 +1,262 @@
+# Ceres Solver - A fast non-linear least squares minimizer
+# Copyright 2015 Google Inc. All rights reserved.
+# http://ceres-solver.org/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Google Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: alexs.mac@gmail.com (Alex Stewart)
+#
+
+# FindCXSparse.cmake - Find CXSparse libraries & dependencies.
+#
+# This module defines the following variables which should be referenced
+# by the caller to use the library.
+#
+# CXSPARSE_FOUND: TRUE iff CXSparse and all dependencies have been found.
+# CXSPARSE_INCLUDE_DIRS: Include directories for CXSparse.
+# CXSPARSE_LIBRARIES: Libraries for CXSparse and all dependencies.
+#
+# CXSPARSE_VERSION: Extracted from cs.h.
+# CXSPARSE_MAIN_VERSION: Equal to 3 if CXSPARSE_VERSION = 3.1.2
+# CXSPARSE_SUB_VERSION: Equal to 1 if CXSPARSE_VERSION = 3.1.2
+# CXSPARSE_SUBSUB_VERSION: Equal to 2 if CXSPARSE_VERSION = 3.1.2
+#
+# The following variables control the behaviour of this module:
+#
+# CXSPARSE_INCLUDE_DIR_HINTS: List of additional directories in which to
+#                             search for CXSparse includes,
+#                             e.g: /timbuktu/include.
+# CXSPARSE_LIBRARY_DIR_HINTS: List of additional directories in which to
+#                             search for CXSparse libraries, e.g: /timbuktu/lib.
+#
+# The following variables are also defined by this module, but in line with
+# CMake recommended FindPackage() module style should NOT be referenced directly
+# by callers (use the plural variables detailed above instead).  These variables
+# do however affect the behaviour of the module via FIND_[PATH/LIBRARY]() which
+# are NOT re-called (i.e. search for library is not repeated) if these variables
+# are set with valid values _in the CMake cache_. This means that if these
+# variables are set directly in the cache, either by the user in the CMake GUI,
+# or by the user passing -DVAR=VALUE directives to CMake when called (which
+# explicitly defines a cache variable), then they will be used verbatim,
+# bypassing the HINTS variables and other hard-coded search locations.
+#
+# CXSPARSE_INCLUDE_DIR: Include directory for CXSparse, not including the
+#                       include directory of any dependencies.
+# CXSPARSE_LIBRARY: CXSparse library, not including the libraries of any
+#                   dependencies.
+
+# Reset CALLERS_CMAKE_FIND_LIBRARY_PREFIXES to its value when
+# FindCXSparse was invoked.
+macro(CXSPARSE_RESET_FIND_LIBRARY_PREFIX)
+  if (MSVC)
+    set(CMAKE_FIND_LIBRARY_PREFIXES "${CALLERS_CMAKE_FIND_LIBRARY_PREFIXES}")
+  endif (MSVC)
+endmacro(CXSPARSE_RESET_FIND_LIBRARY_PREFIX)
+
+# Called if we failed to find CXSparse or any of it's required dependencies,
+# unsets all public (designed to be used externally) variables and reports
+# error message at priority depending upon [REQUIRED/QUIET/<NONE>] argument.
+macro(CXSPARSE_REPORT_NOT_FOUND REASON_MSG)
+  unset(CXSPARSE_FOUND)
+  unset(CXSPARSE_INCLUDE_DIRS)
+  unset(CXSPARSE_LIBRARIES)
+  # Make results of search visible in the CMake GUI if CXSparse has not
+  # been found so that user does not have to toggle to advanced view.
+  mark_as_advanced(CLEAR CXSPARSE_INCLUDE_DIR
+                         CXSPARSE_LIBRARY)
+
+  cxsparse_reset_find_library_prefix()
+
+  # Note <package>_FIND_[REQUIRED/QUIETLY] variables defined by FindPackage()
+  # use the camelcase library name, not uppercase.
+  if (CXSparse_FIND_QUIETLY)
+    message(STATUS "Failed to find CXSparse - " ${REASON_MSG} ${ARGN})
+  elseif (CXSparse_FIND_REQUIRED)
+    message(FATAL_ERROR "Failed to find CXSparse - " ${REASON_MSG} ${ARGN})
+  else()
+    # Neither QUIETLY nor REQUIRED, use no priority which emits a message
+    # but continues configuration and allows generation.
+    message("-- Failed to find CXSparse - " ${REASON_MSG} ${ARGN})
+  endif ()
+  return()
+endmacro(CXSPARSE_REPORT_NOT_FOUND)
+
+# Protect against any alternative find_package scripts for this library having
+# been called previously (in a client project) which set CXSPARSE_FOUND, but not
+# the other variables we require / set here which could cause the search logic
+# here to fail.
+unset(CXSPARSE_FOUND)
+
+# Handle possible presence of lib prefix for libraries on MSVC, see
+# also CXSPARSE_RESET_FIND_LIBRARY_PREFIX().
+if (MSVC)
+  # Preserve the caller's original values for CMAKE_FIND_LIBRARY_PREFIXES
+  # s/t we can set it back before returning.
+  set(CALLERS_CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
+  # The empty string in this list is important, it represents the case when
+  # the libraries have no prefix (shared libraries / DLLs).
+  set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "" "${CMAKE_FIND_LIBRARY_PREFIXES}")
+endif (MSVC)
+
+# On macOS, add the Homebrew prefix (with appropriate suffixes) to the
+# respective HINTS directories (after any user-specified locations).  This
+# handles Homebrew installations into non-standard locations (not /usr/local).
+# We do not use CMAKE_PREFIX_PATH for this as given the search ordering of
+# find_xxx(), doing so would override any user-specified HINTS locations with
+# the Homebrew version if it exists.
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  find_program(HOMEBREW_EXECUTABLE brew)
+  mark_as_advanced(FORCE HOMEBREW_EXECUTABLE)
+  if (HOMEBREW_EXECUTABLE)
+    # Detected a Homebrew install, query for its install prefix.
+    execute_process(COMMAND ${HOMEBREW_EXECUTABLE} --prefix
+      OUTPUT_VARIABLE HOMEBREW_INSTALL_PREFIX
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Detected Homebrew with install prefix: "
+      "${HOMEBREW_INSTALL_PREFIX}, adding to CMake search paths.")
+    list(APPEND CXSPARSE_INCLUDE_DIR_HINTS "${HOMEBREW_INSTALL_PREFIX}/include")
+    list(APPEND CXSPARSE_LIBRARY_DIR_HINTS "${HOMEBREW_INSTALL_PREFIX}/lib")
+  endif()
+endif()
+
+# Search user-installed locations first, so that we prefer user installs
+# to system installs where both exist.
+#
+# TODO: Add standard Windows search locations for CXSparse.
+list(APPEND CXSPARSE_CHECK_INCLUDE_DIRS
+  /usr/local/include
+  /usr/local/homebrew/include # Mac OS X
+  /opt/local/var/macports/software # Mac OS X.
+  /opt/local/include
+  /usr/include)
+list(APPEND CXSPARSE_CHECK_LIBRARY_DIRS
+  /usr/local/lib
+  /usr/local/homebrew/lib # Mac OS X.
+  /opt/local/lib
+  /usr/lib)
+# Additional suffixes to try appending to each search path.
+list(APPEND CXSPARSE_CHECK_PATH_SUFFIXES
+  suitesparse) # Linux/Windows
+
+# Search supplied hint directories first if supplied.
+find_path(CXSPARSE_INCLUDE_DIR
+  NAMES cs.h
+  HINTS ${CXSPARSE_INCLUDE_DIR_HINTS}
+  PATHS ${CXSPARSE_CHECK_INCLUDE_DIRS}
+  PATH_SUFFIXES ${CXSPARSE_CHECK_PATH_SUFFIXES})
+if (NOT CXSPARSE_INCLUDE_DIR OR
+    NOT EXISTS ${CXSPARSE_INCLUDE_DIR})
+  cxsparse_report_not_found(
+    "Could not find CXSparse include directory, set CXSPARSE_INCLUDE_DIR "
+    "to directory containing cs.h")
+endif (NOT CXSPARSE_INCLUDE_DIR OR
+       NOT EXISTS ${CXSPARSE_INCLUDE_DIR})
+
+find_library(CXSPARSE_LIBRARY NAMES cxsparse
+  HINTS ${CXSPARSE_LIBRARY_DIR_HINTS}
+  PATHS ${CXSPARSE_CHECK_LIBRARY_DIRS}
+  PATH_SUFFIXES ${CXSPARSE_CHECK_PATH_SUFFIXES})
+if (NOT CXSPARSE_LIBRARY OR
+    NOT EXISTS ${CXSPARSE_LIBRARY})
+  cxsparse_report_not_found(
+    "Could not find CXSparse library, set CXSPARSE_LIBRARY "
+    "to full path to libcxsparse.")
+endif (NOT CXSPARSE_LIBRARY OR
+       NOT EXISTS ${CXSPARSE_LIBRARY})
+
+# Mark internally as found, then verify. CXSPARSE_REPORT_NOT_FOUND() unsets
+# if called.
+set(CXSPARSE_FOUND TRUE)
+
+# Extract CXSparse version from cs.h
+if (CXSPARSE_INCLUDE_DIR)
+  set(CXSPARSE_VERSION_FILE ${CXSPARSE_INCLUDE_DIR}/cs.h)
+  if (NOT EXISTS ${CXSPARSE_VERSION_FILE})
+    cxsparse_report_not_found(
+      "Could not find file: ${CXSPARSE_VERSION_FILE} "
+      "containing version information in CXSparse install located at: "
+      "${CXSPARSE_INCLUDE_DIR}.")
+  else (NOT EXISTS ${CXSPARSE_VERSION_FILE})
+    file(READ ${CXSPARSE_INCLUDE_DIR}/cs.h CXSPARSE_VERSION_FILE_CONTENTS)
+
+    string(REGEX MATCH "#define CS_VER [0-9]+"
+      CXSPARSE_MAIN_VERSION "${CXSPARSE_VERSION_FILE_CONTENTS}")
+    string(REGEX REPLACE "#define CS_VER ([0-9]+)" "\\1"
+      CXSPARSE_MAIN_VERSION "${CXSPARSE_MAIN_VERSION}")
+
+    string(REGEX MATCH "#define CS_SUBVER [0-9]+"
+      CXSPARSE_SUB_VERSION "${CXSPARSE_VERSION_FILE_CONTENTS}")
+    string(REGEX REPLACE "#define CS_SUBVER ([0-9]+)" "\\1"
+      CXSPARSE_SUB_VERSION "${CXSPARSE_SUB_VERSION}")
+
+    string(REGEX MATCH "#define CS_SUBSUB [0-9]+"
+      CXSPARSE_SUBSUB_VERSION "${CXSPARSE_VERSION_FILE_CONTENTS}")
+    string(REGEX REPLACE "#define CS_SUBSUB ([0-9]+)" "\\1"
+      CXSPARSE_SUBSUB_VERSION "${CXSPARSE_SUBSUB_VERSION}")
+
+    # This is on a single line s/t CMake does not interpret it as a list of
+    # elements and insert ';' separators which would result in 3.;1.;2 nonsense.
+    set(CXSPARSE_VERSION "${CXSPARSE_MAIN_VERSION}.${CXSPARSE_SUB_VERSION}.${CXSPARSE_SUBSUB_VERSION}")
+  endif (NOT EXISTS ${CXSPARSE_VERSION_FILE})
+endif (CXSPARSE_INCLUDE_DIR)
+
+# Catch the case when the caller has set CXSPARSE_LIBRARY in the cache / GUI and
+# thus FIND_LIBRARY was not called, but specified library is invalid, otherwise
+# we would report CXSparse as found.
+# TODO: This regex for CXSparse library is pretty primitive, we use lowercase
+#       for comparison to handle Windows using CamelCase library names, could
+#       this check be better?
+string(TOLOWER "${CXSPARSE_LIBRARY}" LOWERCASE_CXSPARSE_LIBRARY)
+if (CXSPARSE_LIBRARY AND
+    EXISTS ${CXSPARSE_LIBRARY} AND
+    NOT "${LOWERCASE_CXSPARSE_LIBRARY}" MATCHES ".*cxsparse[^/]*")
+  cxsparse_report_not_found(
+    "Caller defined CXSPARSE_LIBRARY: "
+    "${CXSPARSE_LIBRARY} does not match CXSparse.")
+endif (CXSPARSE_LIBRARY AND
+       EXISTS ${CXSPARSE_LIBRARY} AND
+       NOT "${LOWERCASE_CXSPARSE_LIBRARY}" MATCHES ".*cxsparse[^/]*")
+
+# Set standard CMake FindPackage variables if found.
+if (CXSPARSE_FOUND)
+  set(CXSPARSE_INCLUDE_DIRS ${CXSPARSE_INCLUDE_DIR})
+  set(CXSPARSE_LIBRARIES ${CXSPARSE_LIBRARY})
+endif (CXSPARSE_FOUND)
+
+cxsparse_reset_find_library_prefix()
+
+# Handle REQUIRED / QUIET optional arguments and version.
+include(FindPackageHandleStandardArgs)
+find_package_handle_standard_args(CXSparse
+  REQUIRED_VARS CXSPARSE_INCLUDE_DIRS CXSPARSE_LIBRARIES
+  VERSION_VAR CXSPARSE_VERSION)
+
+# Only mark internal variables as advanced if we found CXSparse, otherwise
+# leave them visible in the standard GUI for the user to set manually.
+if (CXSPARSE_FOUND)
+  mark_as_advanced(FORCE CXSPARSE_INCLUDE_DIR
+                         CXSPARSE_LIBRARY)
+endif (CXSPARSE_FOUND)
+

--- a/cmake/FindSuiteSparse.cmake
+++ b/cmake/FindSuiteSparse.cmake
@@ -1,0 +1,531 @@
+# Ceres Solver - A fast non-linear least squares minimizer
+# Copyright 2015 Google Inc. All rights reserved.
+# http://ceres-solver.org/
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# * Redistributions of source code must retain the above copyright notice,
+#   this list of conditions and the following disclaimer.
+# * Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# * Neither the name of Google Inc. nor the names of its contributors may be
+#   used to endorse or promote products derived from this software without
+#   specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+#
+# Author: alexs.mac@gmail.com (Alex Stewart)
+#
+
+# FindSuiteSparse.cmake - Find SuiteSparse libraries & dependencies.
+#
+# This module defines the following variables:
+#
+# SUITESPARSE_FOUND: TRUE iff SuiteSparse and all dependencies have been found.
+# SUITESPARSE_INCLUDE_DIRS: Include directories for all SuiteSparse components.
+# SUITESPARSE_LIBRARIES: Libraries for all SuiteSparse component libraries and
+#                        dependencies.
+# SUITESPARSE_VERSION: Extracted from UFconfig.h (<= v3) or
+#                      SuiteSparse_config.h (>= v4).
+# SUITESPARSE_MAIN_VERSION: Equal to 4 if SUITESPARSE_VERSION = 4.2.1
+# SUITESPARSE_SUB_VERSION: Equal to 2 if SUITESPARSE_VERSION = 4.2.1
+# SUITESPARSE_SUBSUB_VERSION: Equal to 1 if SUITESPARSE_VERSION = 4.2.1
+#
+# SUITESPARSE_IS_BROKEN_SHARED_LINKING_UBUNTU_SYSTEM_VERSION: TRUE iff running
+#     on Ubuntu, SUITESPARSE_VERSION is 3.4.0 and found SuiteSparse is a system
+#     install, in which case found version of SuiteSparse cannot be used to link
+#     a shared library due to a bug (static linking is unaffected).
+#
+# The following variables control the behaviour of this module:
+#
+# SUITESPARSE_INCLUDE_DIR_HINTS: List of additional directories in which to
+#                                search for SuiteSparse includes,
+#                                e.g: /timbuktu/include.
+# SUITESPARSE_LIBRARY_DIR_HINTS: List of additional directories in which to
+#                                search for SuiteSparse libraries,
+#                                e.g: /timbuktu/lib.
+#
+# The following variables define the presence / includes & libraries for the
+# SuiteSparse components searched for, the SUITESPARSE_XX variables are the
+# union of the variables for all components.
+#
+# == Symmetric Approximate Minimum Degree (AMD)
+# AMD_FOUND
+# AMD_INCLUDE_DIR
+# AMD_LIBRARY
+#
+# == Constrained Approximate Minimum Degree (CAMD)
+# CAMD_FOUND
+# CAMD_INCLUDE_DIR
+# CAMD_LIBRARY
+#
+# == Column Approximate Minimum Degree (COLAMD)
+# COLAMD_FOUND
+# COLAMD_INCLUDE_DIR
+# COLAMD_LIBRARY
+#
+# Constrained Column Approximate Minimum Degree (CCOLAMD)
+# CCOLAMD_FOUND
+# CCOLAMD_INCLUDE_DIR
+# CCOLAMD_LIBRARY
+#
+# == Sparse Supernodal Cholesky Factorization and Update/Downdate (CHOLMOD)
+# CHOLMOD_FOUND
+# CHOLMOD_INCLUDE_DIR
+# CHOLMOD_LIBRARY
+#
+# == Multifrontal Sparse QR (SuiteSparseQR)
+# SUITESPARSEQR_FOUND
+# SUITESPARSEQR_INCLUDE_DIR
+# SUITESPARSEQR_LIBRARY
+#
+# == Common configuration for all but CSparse (SuiteSparse version >= 4).
+# SUITESPARSE_CONFIG_FOUND
+# SUITESPARSE_CONFIG_INCLUDE_DIR
+# SUITESPARSE_CONFIG_LIBRARY
+#
+# == Common configuration for all but CSparse (SuiteSparse version < 4).
+# UFCONFIG_FOUND
+# UFCONFIG_INCLUDE_DIR
+#
+# Optional SuiteSparse Dependencies:
+#
+# == Serial Graph Partitioning and Fill-reducing Matrix Ordering (METIS)
+# METIS_FOUND
+# METIS_LIBRARY
+
+# Reset CALLERS_CMAKE_FIND_LIBRARY_PREFIXES to its value when
+# FindSuiteSparse was invoked.
+macro(SUITESPARSE_RESET_FIND_LIBRARY_PREFIX)
+  if (MSVC)
+    set(CMAKE_FIND_LIBRARY_PREFIXES "${CALLERS_CMAKE_FIND_LIBRARY_PREFIXES}")
+  endif (MSVC)
+endmacro(SUITESPARSE_RESET_FIND_LIBRARY_PREFIX)
+
+# Called if we failed to find SuiteSparse or any of it's required dependencies,
+# unsets all public (designed to be used externally) variables and reports
+# error message at priority depending upon [REQUIRED/QUIET/<NONE>] argument.
+macro(SUITESPARSE_REPORT_NOT_FOUND REASON_MSG)
+  unset(SUITESPARSE_FOUND)
+  unset(SUITESPARSE_INCLUDE_DIRS)
+  unset(SUITESPARSE_LIBRARIES)
+  unset(SUITESPARSE_VERSION)
+  unset(SUITESPARSE_MAIN_VERSION)
+  unset(SUITESPARSE_SUB_VERSION)
+  unset(SUITESPARSE_SUBSUB_VERSION)
+  # Do NOT unset SUITESPARSE_FOUND_REQUIRED_VARS here, as it is used by
+  # FindPackageHandleStandardArgs() to generate the automatic error message on
+  # failure which highlights which components are missing.
+
+  suitesparse_reset_find_library_prefix()
+
+  # Note <package>_FIND_[REQUIRED/QUIETLY] variables defined by FindPackage()
+  # use the camelcase library name, not uppercase.
+  if (SuiteSparse_FIND_QUIETLY)
+    message(STATUS "Failed to find SuiteSparse - " ${REASON_MSG} ${ARGN})
+  elseif (SuiteSparse_FIND_REQUIRED)
+    message(FATAL_ERROR "Failed to find SuiteSparse - " ${REASON_MSG} ${ARGN})
+  else()
+    # Neither QUIETLY nor REQUIRED, use no priority which emits a message
+    # but continues configuration and allows generation.
+    message("-- Failed to find SuiteSparse - " ${REASON_MSG} ${ARGN})
+  endif (SuiteSparse_FIND_QUIETLY)
+
+  # Do not call return(), s/t we keep processing if not called with REQUIRED
+  # and report all missing components, rather than bailing after failing to find
+  # the first.
+endmacro(SUITESPARSE_REPORT_NOT_FOUND)
+
+# Protect against any alternative find_package scripts for this library having
+# been called previously (in a client project) which set SUITESPARSE_FOUND, but
+# not the other variables we require / set here which could cause the search
+# logic here to fail.
+unset(SUITESPARSE_FOUND)
+
+# Handle possible presence of lib prefix for libraries on MSVC, see
+# also SUITESPARSE_RESET_FIND_LIBRARY_PREFIX().
+if (MSVC)
+  # Preserve the caller's original values for CMAKE_FIND_LIBRARY_PREFIXES
+  # s/t we can set it back before returning.
+  set(CALLERS_CMAKE_FIND_LIBRARY_PREFIXES "${CMAKE_FIND_LIBRARY_PREFIXES}")
+  # The empty string in this list is important, it represents the case when
+  # the libraries have no prefix (shared libraries / DLLs).
+  set(CMAKE_FIND_LIBRARY_PREFIXES "lib" "" "${CMAKE_FIND_LIBRARY_PREFIXES}")
+endif (MSVC)
+
+# On macOS, add the Homebrew prefix (with appropriate suffixes) to the
+# respective HINTS directories (after any user-specified locations).  This
+# handles Homebrew installations into non-standard locations (not /usr/local).
+# We do not use CMAKE_PREFIX_PATH for this as given the search ordering of
+# find_xxx(), doing so would override any user-specified HINTS locations with
+# the Homebrew version if it exists.
+if (CMAKE_SYSTEM_NAME MATCHES "Darwin")
+  find_program(HOMEBREW_EXECUTABLE brew)
+  mark_as_advanced(FORCE HOMEBREW_EXECUTABLE)
+  if (HOMEBREW_EXECUTABLE)
+    # Detected a Homebrew install, query for its install prefix.
+    execute_process(COMMAND ${HOMEBREW_EXECUTABLE} --prefix
+      OUTPUT_VARIABLE HOMEBREW_INSTALL_PREFIX
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+    message(STATUS "Detected Homebrew with install prefix: "
+      "${HOMEBREW_INSTALL_PREFIX}, adding to CMake search paths.")
+    list(APPEND SUITESPARSE_INCLUDE_DIR_HINTS "${HOMEBREW_INSTALL_PREFIX}/include")
+    list(APPEND SUITESPARSE_LIBRARY_DIR_HINTS "${HOMEBREW_INSTALL_PREFIX}/lib")
+  endif()
+endif()
+
+# Specify search directories for include files and libraries (this is the union
+# of the search directories for all OSs).  Search user-specified hint
+# directories first if supplied, and search user-installed locations first
+# so that we prefer user installs to system installs where both exist.
+list(APPEND SUITESPARSE_CHECK_INCLUDE_DIRS
+  /opt/local/include
+  /opt/local/include/ufsparse # Mac OS X
+  /usr/local/homebrew/include # Mac OS X
+  /usr/local/include
+  /usr/include)
+list(APPEND SUITESPARSE_CHECK_LIBRARY_DIRS
+  /opt/local/lib
+  /opt/local/lib/ufsparse # Mac OS X
+  /usr/local/homebrew/lib # Mac OS X
+  /usr/local/lib
+  /usr/lib)
+# Additional suffixes to try appending to each search path.
+list(APPEND SUITESPARSE_CHECK_PATH_SUFFIXES
+  suitesparse) # Windows/Ubuntu
+
+# Wrappers to find_path/library that pass the SuiteSparse search hints/paths.
+#
+# suitesparse_find_component(<component> [FILES name1 [name2 ...]]
+#                                        [LIBRARIES name1 [name2 ...]]
+#                                        [REQUIRED])
+macro(suitesparse_find_component COMPONENT)
+  include(CMakeParseArguments)
+  set(OPTIONS REQUIRED)
+  set(MULTI_VALUE_ARGS FILES LIBRARIES)
+  cmake_parse_arguments(SUITESPARSE_FIND_${COMPONENT}
+    "${OPTIONS}" "" "${MULTI_VALUE_ARGS}" ${ARGN})
+
+  if (SUITESPARSE_FIND_${COMPONENT}_REQUIRED)
+    list(APPEND SUITESPARSE_FOUND_REQUIRED_VARS ${COMPONENT}_FOUND)
+  endif()
+
+  set(${COMPONENT}_FOUND TRUE)
+  if (SUITESPARSE_FIND_${COMPONENT}_FILES)
+    find_path(${COMPONENT}_INCLUDE_DIR
+      NAMES ${SUITESPARSE_FIND_${COMPONENT}_FILES}
+      HINTS ${SUITESPARSE_INCLUDE_DIR_HINTS}
+      PATHS ${SUITESPARSE_CHECK_INCLUDE_DIRS}
+      PATH_SUFFIXES ${SUITESPARSE_CHECK_PATH_SUFFIXES})
+    if (${COMPONENT}_INCLUDE_DIR)
+      message(STATUS "Found ${COMPONENT} headers in: "
+        "${${COMPONENT}_INCLUDE_DIR}")
+      mark_as_advanced(${COMPONENT}_INCLUDE_DIR)
+    else()
+      # Specified headers not found.
+      set(${COMPONENT}_FOUND FALSE)
+      if (SUITESPARSE_FIND_${COMPONENT}_REQUIRED)
+        suitesparse_report_not_found(
+          "Did not find ${COMPONENT} header (required SuiteSparse component).")
+      else()
+        message(STATUS "Did not find ${COMPONENT} header (optional "
+          "SuiteSparse component).")
+        # Hide optional vars from CMake GUI even if not found.
+        mark_as_advanced(${COMPONENT}_INCLUDE_DIR)
+      endif()
+    endif()
+  endif()
+
+  if (SUITESPARSE_FIND_${COMPONENT}_LIBRARIES)
+    find_library(${COMPONENT}_LIBRARY
+      NAMES ${SUITESPARSE_FIND_${COMPONENT}_LIBRARIES}
+      HINTS ${SUITESPARSE_LIBRARY_DIR_HINTS}
+      PATHS ${SUITESPARSE_CHECK_LIBRARY_DIRS}
+      PATH_SUFFIXES ${SUITESPARSE_CHECK_PATH_SUFFIXES})
+    if (${COMPONENT}_LIBRARY)
+      message(STATUS "Found ${COMPONENT} library: ${${COMPONENT}_LIBRARY}")
+      mark_as_advanced(${COMPONENT}_LIBRARY)
+    else ()
+      # Specified libraries not found.
+      set(${COMPONENT}_FOUND FALSE)
+      if (SUITESPARSE_FIND_${COMPONENT}_REQUIRED)
+        suitesparse_report_not_found(
+          "Did not find ${COMPONENT} library (required SuiteSparse component).")
+      else()
+        message(STATUS "Did not find ${COMPONENT} library (optional SuiteSparse "
+          "dependency)")
+        # Hide optional vars from CMake GUI even if not found.
+        mark_as_advanced(${COMPONENT}_LIBRARY)
+      endif()
+    endif()
+  endif()
+endmacro()
+
+# Given the number of components of SuiteSparse, and to ensure that the
+# automatic failure message generated by FindPackageHandleStandardArgs()
+# when not all required components are found is helpful, we maintain a list
+# of all variables that must be defined for SuiteSparse to be considered found.
+unset(SUITESPARSE_FOUND_REQUIRED_VARS)
+
+# BLAS.
+find_package(BLAS QUIET)
+if (NOT BLAS_FOUND)
+  suitesparse_report_not_found(
+    "Did not find BLAS library (required for SuiteSparse).")
+endif (NOT BLAS_FOUND)
+list(APPEND SUITESPARSE_FOUND_REQUIRED_VARS BLAS_FOUND)
+
+# LAPACK.
+find_package(LAPACK QUIET)
+if (NOT LAPACK_FOUND)
+  suitesparse_report_not_found(
+    "Did not find LAPACK library (required for SuiteSparse).")
+endif (NOT LAPACK_FOUND)
+list(APPEND SUITESPARSE_FOUND_REQUIRED_VARS LAPACK_FOUND)
+
+suitesparse_find_component(AMD REQUIRED FILES amd.h LIBRARIES amd)
+suitesparse_find_component(CAMD REQUIRED FILES camd.h LIBRARIES camd)
+suitesparse_find_component(COLAMD REQUIRED FILES colamd.h LIBRARIES colamd)
+suitesparse_find_component(CCOLAMD REQUIRED FILES ccolamd.h LIBRARIES ccolamd)
+suitesparse_find_component(CHOLMOD REQUIRED FILES cholmod.h LIBRARIES cholmod)
+suitesparse_find_component(
+  SUITESPARSEQR REQUIRED FILES SuiteSparseQR.hpp LIBRARIES spqr)
+if (SUITESPARSEQR_FOUND)
+  # SuiteSparseQR may be compiled with Intel Threading Building Blocks,
+  # we assume that if TBB is installed, SuiteSparseQR was compiled with
+  # support for it, this will do no harm if it wasn't.
+  find_package(TBB QUIET)
+  if (TBB_FOUND)
+    message(STATUS "Found Intel Thread Building Blocks (TBB) library "
+      "(${TBB_VERSION}) assuming SuiteSparseQR was compiled "
+      "with TBB.")
+    # Add the TBB libraries to the SuiteSparseQR libraries (the only
+    # libraries to optionally depend on TBB).
+    list(APPEND SUITESPARSEQR_LIBRARY ${TBB_LIBRARIES})
+  else()
+    message(STATUS "Did not find Intel TBB library, assuming SuiteSparseQR was "
+      "not compiled with TBB.")
+  endif()
+endif(SUITESPARSEQR_FOUND)
+
+# UFconfig / SuiteSparse_config.
+#
+# If SuiteSparse version is >= 4 then SuiteSparse_config is required.
+# For SuiteSparse 3, UFconfig.h is required.
+suitesparse_find_component(
+  SUITESPARSE_CONFIG FILES SuiteSparse_config.h LIBRARIES suitesparseconfig)
+
+if (SUITESPARSE_CONFIG_FOUND)
+  # SuiteSparse_config (SuiteSparse version >= 4) requires librt library for
+  # timing by default when compiled on Linux or Unix, but not on OSX (which
+  # does not have librt).
+  if (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX AND NOT APPLE)
+    suitesparse_find_component(LIBRT LIBRARIES rt)
+    if (LIBRT_FOUND)
+      message(STATUS "Adding librt: ${LIBRT_LIBRARY} to "
+        "SuiteSparse_config libraries (required on Linux & Unix [not OSX] if "
+        "SuiteSparse is compiled with timing).")
+      list(APPEND SUITESPARSE_CONFIG_LIBRARY ${LIBRT_LIBRARY})
+    else()
+      message(STATUS "Could not find librt, but found SuiteSparse_config, "
+        "assuming that SuiteSparse was compiled without timing.")
+    endif ()
+  endif (CMAKE_SYSTEM_NAME MATCHES "Linux" OR UNIX AND NOT APPLE)
+else()
+  # Failed to find SuiteSparse_config (>= v4 installs), instead look for
+  # UFconfig header which should be present in < v4 installs.
+  suitesparse_find_component(UFCONFIG FILES UFconfig.h)
+endif ()
+
+if (NOT SUITESPARSE_CONFIG_FOUND AND
+    NOT UFCONFIG_FOUND)
+  suitesparse_report_not_found(
+    "Failed to find either: SuiteSparse_config header & library (should be "
+    "present in all SuiteSparse >= v4 installs), or UFconfig header (should "
+    "be present in all SuiteSparse < v4 installs).")
+endif()
+
+# Extract the SuiteSparse version from the appropriate header (UFconfig.h for
+# <= v3, SuiteSparse_config.h for >= v4).
+list(APPEND SUITESPARSE_FOUND_REQUIRED_VARS SUITESPARSE_VERSION)
+
+if (UFCONFIG_FOUND)
+  # SuiteSparse version <= 3.
+  set(SUITESPARSE_VERSION_FILE ${UFCONFIG_INCLUDE_DIR}/UFconfig.h)
+  if (NOT EXISTS ${SUITESPARSE_VERSION_FILE})
+    suitesparse_report_not_found(
+      "Could not find file: ${SUITESPARSE_VERSION_FILE} containing version "
+      "information for <= v3 SuiteSparse installs, but UFconfig was found "
+      "(only present in <= v3 installs).")
+  else (NOT EXISTS ${SUITESPARSE_VERSION_FILE})
+    file(READ ${SUITESPARSE_VERSION_FILE} UFCONFIG_CONTENTS)
+
+    string(REGEX MATCH "#define SUITESPARSE_MAIN_VERSION [0-9]+"
+      SUITESPARSE_MAIN_VERSION "${UFCONFIG_CONTENTS}")
+    string(REGEX REPLACE "#define SUITESPARSE_MAIN_VERSION ([0-9]+)" "\\1"
+      SUITESPARSE_MAIN_VERSION "${SUITESPARSE_MAIN_VERSION}")
+
+    string(REGEX MATCH "#define SUITESPARSE_SUB_VERSION [0-9]+"
+      SUITESPARSE_SUB_VERSION "${UFCONFIG_CONTENTS}")
+    string(REGEX REPLACE "#define SUITESPARSE_SUB_VERSION ([0-9]+)" "\\1"
+      SUITESPARSE_SUB_VERSION "${SUITESPARSE_SUB_VERSION}")
+
+    string(REGEX MATCH "#define SUITESPARSE_SUBSUB_VERSION [0-9]+"
+      SUITESPARSE_SUBSUB_VERSION "${UFCONFIG_CONTENTS}")
+    string(REGEX REPLACE "#define SUITESPARSE_SUBSUB_VERSION ([0-9]+)" "\\1"
+      SUITESPARSE_SUBSUB_VERSION "${SUITESPARSE_SUBSUB_VERSION}")
+
+    # This is on a single line s/t CMake does not interpret it as a list of
+    # elements and insert ';' separators which would result in 4.;2.;1 nonsense.
+    set(SUITESPARSE_VERSION
+      "${SUITESPARSE_MAIN_VERSION}.${SUITESPARSE_SUB_VERSION}.${SUITESPARSE_SUBSUB_VERSION}")
+  endif (NOT EXISTS ${SUITESPARSE_VERSION_FILE})
+endif (UFCONFIG_FOUND)
+
+if (SUITESPARSE_CONFIG_FOUND)
+  # SuiteSparse version >= 4.
+  set(SUITESPARSE_VERSION_FILE
+    ${SUITESPARSE_CONFIG_INCLUDE_DIR}/SuiteSparse_config.h)
+  if (NOT EXISTS ${SUITESPARSE_VERSION_FILE})
+    suitesparse_report_not_found(
+      "Could not find file: ${SUITESPARSE_VERSION_FILE} containing version "
+      "information for >= v4 SuiteSparse installs, but SuiteSparse_config was "
+      "found (only present in >= v4 installs).")
+  else (NOT EXISTS ${SUITESPARSE_VERSION_FILE})
+    file(READ ${SUITESPARSE_VERSION_FILE} SUITESPARSE_CONFIG_CONTENTS)
+
+    string(REGEX MATCH "#define SUITESPARSE_MAIN_VERSION [0-9]+"
+      SUITESPARSE_MAIN_VERSION "${SUITESPARSE_CONFIG_CONTENTS}")
+    string(REGEX REPLACE "#define SUITESPARSE_MAIN_VERSION ([0-9]+)" "\\1"
+      SUITESPARSE_MAIN_VERSION "${SUITESPARSE_MAIN_VERSION}")
+
+    string(REGEX MATCH "#define SUITESPARSE_SUB_VERSION [0-9]+"
+      SUITESPARSE_SUB_VERSION "${SUITESPARSE_CONFIG_CONTENTS}")
+    string(REGEX REPLACE "#define SUITESPARSE_SUB_VERSION ([0-9]+)" "\\1"
+      SUITESPARSE_SUB_VERSION "${SUITESPARSE_SUB_VERSION}")
+
+    string(REGEX MATCH "#define SUITESPARSE_SUBSUB_VERSION [0-9]+"
+      SUITESPARSE_SUBSUB_VERSION "${SUITESPARSE_CONFIG_CONTENTS}")
+    string(REGEX REPLACE "#define SUITESPARSE_SUBSUB_VERSION ([0-9]+)" "\\1"
+      SUITESPARSE_SUBSUB_VERSION "${SUITESPARSE_SUBSUB_VERSION}")
+
+    # This is on a single line s/t CMake does not interpret it as a list of
+    # elements and insert ';' separators which would result in 4.;2.;1 nonsense.
+    set(SUITESPARSE_VERSION
+      "${SUITESPARSE_MAIN_VERSION}.${SUITESPARSE_SUB_VERSION}.${SUITESPARSE_SUBSUB_VERSION}")
+  endif (NOT EXISTS ${SUITESPARSE_VERSION_FILE})
+endif (SUITESPARSE_CONFIG_FOUND)
+
+# METIS (Optional dependency).
+suitesparse_find_component(METIS LIBRARIES metis)
+
+# Only mark SuiteSparse as found if all required components and dependencies
+# have been found.
+set(SUITESPARSE_FOUND TRUE)
+foreach(REQUIRED_VAR ${SUITESPARSE_FOUND_REQUIRED_VARS})
+  if (NOT ${REQUIRED_VAR})
+    set(SUITESPARSE_FOUND FALSE)
+  endif (NOT ${REQUIRED_VAR})
+endforeach(REQUIRED_VAR ${SUITESPARSE_FOUND_REQUIRED_VARS})
+
+if (SUITESPARSE_FOUND)
+  list(APPEND SUITESPARSE_INCLUDE_DIRS
+    ${AMD_INCLUDE_DIR}
+    ${CAMD_INCLUDE_DIR}
+    ${COLAMD_INCLUDE_DIR}
+    ${CCOLAMD_INCLUDE_DIR}
+    ${CHOLMOD_INCLUDE_DIR}
+    ${SUITESPARSEQR_INCLUDE_DIR})
+  # Handle config separately, as otherwise at least one of them will be set
+  # to NOTFOUND which would cause any check on SUITESPARSE_INCLUDE_DIRS to fail.
+  if (SUITESPARSE_CONFIG_FOUND)
+    list(APPEND SUITESPARSE_INCLUDE_DIRS
+      ${SUITESPARSE_CONFIG_INCLUDE_DIR})
+  endif (SUITESPARSE_CONFIG_FOUND)
+  if (UFCONFIG_FOUND)
+    list(APPEND SUITESPARSE_INCLUDE_DIRS
+      ${UFCONFIG_INCLUDE_DIR})
+  endif (UFCONFIG_FOUND)
+  # As SuiteSparse includes are often all in the same directory, remove any
+  # repetitions.
+  list(REMOVE_DUPLICATES SUITESPARSE_INCLUDE_DIRS)
+
+  # Important: The ordering of these libraries is *NOT* arbitrary, as these
+  # could potentially be static libraries their link ordering is important.
+  list(APPEND SUITESPARSE_LIBRARIES
+    ${SUITESPARSEQR_LIBRARY}
+    ${CHOLMOD_LIBRARY}
+    ${CCOLAMD_LIBRARY}
+    ${CAMD_LIBRARY}
+    ${COLAMD_LIBRARY}
+    ${AMD_LIBRARY}
+    ${LAPACK_LIBRARIES}
+    ${BLAS_LIBRARIES})
+  if (SUITESPARSE_CONFIG_FOUND)
+    list(APPEND SUITESPARSE_LIBRARIES
+      ${SUITESPARSE_CONFIG_LIBRARY})
+  endif (SUITESPARSE_CONFIG_FOUND)
+  if (METIS_FOUND)
+    list(APPEND SUITESPARSE_LIBRARIES
+      ${METIS_LIBRARY})
+  endif (METIS_FOUND)
+endif()
+
+# Determine if we are running on Ubuntu with the package install of SuiteSparse
+# which is broken and does not support linking a shared library.
+set(SUITESPARSE_IS_BROKEN_SHARED_LINKING_UBUNTU_SYSTEM_VERSION FALSE)
+if (CMAKE_SYSTEM_NAME MATCHES "Linux" AND
+    SUITESPARSE_VERSION VERSION_EQUAL 3.4.0)
+  find_program(LSB_RELEASE_EXECUTABLE lsb_release)
+  if (LSB_RELEASE_EXECUTABLE)
+    # Any even moderately recent Ubuntu release (likely to be affected by
+    # this bug) should have lsb_release, if it isn't present we are likely
+    # on a different Linux distribution (should be fine).
+    execute_process(COMMAND ${LSB_RELEASE_EXECUTABLE} -si
+      OUTPUT_VARIABLE LSB_DISTRIBUTOR_ID
+      OUTPUT_STRIP_TRAILING_WHITESPACE)
+
+    if (LSB_DISTRIBUTOR_ID MATCHES "Ubuntu" AND
+        SUITESPARSE_LIBRARIES MATCHES "/usr/lib/libamd")
+      # We are on Ubuntu, and the SuiteSparse version matches the broken
+      # system install version and is a system install.
+      set(SUITESPARSE_IS_BROKEN_SHARED_LINKING_UBUNTU_SYSTEM_VERSION TRUE)
+      message(STATUS "Found system install of SuiteSparse "
+        "${SUITESPARSE_VERSION} running on Ubuntu, which has a known bug "
+        "preventing linking of shared libraries (static linking unaffected).")
+    endif (LSB_DISTRIBUTOR_ID MATCHES "Ubuntu" AND
+      SUITESPARSE_LIBRARIES MATCHES "/usr/lib/libamd")
+  endif (LSB_RELEASE_EXECUTABLE)
+endif (CMAKE_SYSTEM_NAME MATCHES "Linux" AND
+  SUITESPARSE_VERSION VERSION_EQUAL 3.4.0)
+
+suitesparse_reset_find_library_prefix()
+
+# Handle REQUIRED and QUIET arguments to FIND_PACKAGE
+include(FindPackageHandleStandardArgs)
+if (SUITESPARSE_FOUND)
+  find_package_handle_standard_args(SuiteSparse
+    REQUIRED_VARS ${SUITESPARSE_FOUND_REQUIRED_VARS}
+    VERSION_VAR SUITESPARSE_VERSION
+    FAIL_MESSAGE "Failed to find some/all required components of SuiteSparse.")
+else (SUITESPARSE_FOUND)
+  # Do not pass VERSION_VAR to FindPackageHandleStandardArgs() if we failed to
+  # find SuiteSparse to avoid a confusing autogenerated failure message
+  # that states 'not found (missing: FOO) (found version: x.y.z)'.
+  find_package_handle_standard_args(SuiteSparse
+    REQUIRED_VARS ${SUITESPARSE_FOUND_REQUIRED_VARS}
+    FAIL_MESSAGE "Failed to find some/all required components of SuiteSparse.")
+endif (SUITESPARSE_FOUND)
+

--- a/include/sparse_bundle_adjustment/bpcg/bpcg.h
+++ b/include/sparse_bundle_adjustment/bpcg/bpcg.h
@@ -68,7 +68,7 @@ namespace sba
       jacobiBPCG() { residual = 0.0; };
       int doBPCG(int iters, double tol,
                  vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
-                 vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<Matrix<double,N,N> > > > &cols,
+                 vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > > &cols,
                  VectorXd &x,
                  VectorXd &b,
                  bool abstol = false,
@@ -78,7 +78,7 @@ namespace sba
       // uses internal linear storage for Hessian
       int doBPCG2(int iters, double tol,
                  vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
-                 vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<Matrix<double,N,N> > > > &cols,
+                 vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > > &cols,
                  VectorXd &x,
                  VectorXd &b,
                  bool abstol = false,
@@ -88,8 +88,8 @@ namespace sba
       double residual;
 
     private:
-      void mMV(vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
-               vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<Matrix<double,N,N> > > > &cols,
+      void mMV(vector< Matrix<double,N,N>, aligned_allocator< Matrix<double,N,N> > > &diag,
+               vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > > &cols,
                const VectorXd &vin,
                VectorXd &vout);
  
@@ -98,7 +98,7 @@ namespace sba
                 const VectorXd &vin,
                 VectorXd &vout);
  
-      void mD(vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
+      void mD(vector< Matrix<double,N,N>, aligned_allocator< Matrix<double,N,N> > > &diag,
               VectorXd &vin,
               VectorXd &vout);
 
@@ -108,7 +108,7 @@ namespace sba
 
   template <int N>
     void jacobiBPCG<N>::mMV(vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
-                        vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<Matrix<double,N,N> > > > &cols,
+                        vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > > &cols,
                         const VectorXd &vin,
                         VectorXd &vout)
     {
@@ -119,11 +119,11 @@ namespace sba
             vout.segment<N>(i*N) = diag[i]*vin.segment<N>(i*N); // only works with cols ordering
 
             map<int,Matrix<double,N,N>, less<int>, 
-              aligned_allocator<Matrix<double,N,N> > > &col = cols[i];
+              aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > &col = cols[i];
             if (col.size() > 0)
               {
                 typename map<int,Matrix<double,N,N>, less<int>, // need "typename" here, barf
-                  aligned_allocator<Matrix<double,N,N > > >::iterator it;
+                  aligned_allocator<std::pair<const int, Matrix<double,N,N >> > >::iterator it;
                 for (it = col.begin(); it != col.end(); it++)
                   {
                     int ri = (*it).first; // get row index
@@ -177,7 +177,7 @@ namespace sba
   template <int N>
     int jacobiBPCG<N>::doBPCG(int iters, double tol,
 	    vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
-	    vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<Matrix<double,N,N> > > > &cols,
+	    vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > > &cols,
 	    VectorXd &x,
 	    VectorXd &b,
 	    bool abstol,
@@ -237,7 +237,7 @@ namespace sba
   template <int N>
     int jacobiBPCG<N>::doBPCG2(int iters, double tol,
 	    vector< Matrix<double,N,N>, aligned_allocator<Matrix<double,N,N> > > &diag,
-	    vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<Matrix<double,N,N> > > > &cols,
+	    vector< map<int,Matrix<double,N,N>, less<int>, aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > > &cols,
 	    VectorXd &x,
 	    VectorXd &b,
 	    bool abstol,
@@ -260,11 +260,11 @@ namespace sba
       for (int i=0; i<(int)cols.size(); i++)
         {
           map<int,Matrix<double,N,N>, less<int>, 
-            aligned_allocator<Matrix<double,N,N> > > &col = cols[i];
+            aligned_allocator<std::pair<const int, Matrix<double,N,N>> > > &col = cols[i];
           if (col.size() > 0)
             {
               typename map<int,Matrix<double,N,N>, less<int>, 
-                aligned_allocator<Matrix<double,N,N> > >::iterator it;
+                aligned_allocator<std::pair<const int, Matrix<double,N,N>> > >::iterator it;
               for (it = col.begin(); it != col.end(); it++)
                 {
                   int ri = (*it).first; // get row index

--- a/include/sparse_bundle_adjustment/csparse.h
+++ b/include/sparse_bundle_adjustment/csparse.h
@@ -52,14 +52,14 @@
 
 // CSparse header
 extern "C" {
-#include "suitesparse/cs.h"
+#include "cs.h"
 }
 #include <vector>
 #include <map>
 
 // Cholmod header, other header files brought in
 #ifdef SBA_CHOLMOD
-#include "suitesparse/cholmod.h"
+#include "cholmod.h"
 #endif
 
 // these are for SparseLib and IML, testing the Delayed State Filter
@@ -93,7 +93,7 @@ namespace sba
     vector< Matrix<double,6,6>, aligned_allocator<Matrix<double,6,6> > > diag;
     // compressed column storage of blocks
     vector< map<int,Matrix<double,6,6>, less<int>, 
-                aligned_allocator<Matrix<double,6,6> > > > cols;
+                aligned_allocator<std::pair<const int, Matrix<double,6,6>> > > > cols;
 
     void setupBlockStructure(int n); // size of rows/cols of A (in blocks)
     
@@ -158,7 +158,7 @@ namespace sba
     vector< Matrix<double,3,3>, aligned_allocator<Matrix<double,3,3> > > diag;
     // compressed column storage of blocks
     vector< map<int,Matrix<double,3,3>, less<int>, 
-                aligned_allocator<Matrix<double,3,3> > > > cols;
+                aligned_allocator<std::pair<const int, Matrix<double,3,3>> > > > cols;
 
     void setupBlockStructure(int n, bool eraseit = true); // size of rows/cols of A (in blocks)
     

--- a/include/sparse_bundle_adjustment/proj.h
+++ b/include/sparse_bundle_adjustment/proj.h
@@ -73,8 +73,6 @@ namespace sba
       /// \brief Default constructor. Initializes to default values, 
       /// kp = <0 0 0> and ndi = <0>. Also sets the projection to be invalid.
       Proj();
-
-      //Proj & operator=(const Proj&) = delete;
       
       /// Node index, the camera node for this projection.
       int ndi;
@@ -189,8 +187,6 @@ namespace sba
       
       /// Default constructor for Track.
       Track();
-
-      //Track & operator=(const Track&) = delete;
       
       /// \brief A map of all the projections of the point with camera index 
       /// as key, based off an STL map.

--- a/include/sparse_bundle_adjustment/proj.h
+++ b/include/sparse_bundle_adjustment/proj.h
@@ -49,7 +49,7 @@ namespace sba
   
   /// Obnoxiously long type def for the map type that holds the point 
   /// projections in tracks.
-  typedef std::map<int, Proj> ProjMap; //, std::less<int>, Eigen::aligned_allocator<std::pair<int, Proj>> 
+  typedef std::map<int, Proj> ProjMap;
 
   /// \brief Proj holds a projection measurement of a point onto a
   /// frame. They are a repository for the link between the frame and

--- a/include/sparse_bundle_adjustment/proj.h
+++ b/include/sparse_bundle_adjustment/proj.h
@@ -49,7 +49,7 @@ namespace sba
   
   /// Obnoxiously long type def for the map type that holds the point 
   /// projections in tracks.
-  typedef std::map<const int, Proj, std::less<int>, Eigen::aligned_allocator<std::pair<const int, Proj>> > ProjMap;
+  typedef std::map<int, Proj> ProjMap; //, std::less<int>, Eigen::aligned_allocator<std::pair<int, Proj>> 
 
   /// \brief Proj holds a projection measurement of a point onto a
   /// frame. They are a repository for the link between the frame and

--- a/include/sparse_bundle_adjustment/proj.h
+++ b/include/sparse_bundle_adjustment/proj.h
@@ -49,7 +49,7 @@ namespace sba
   
   /// Obnoxiously long type def for the map type that holds the point 
   /// projections in tracks.
-  typedef std::map<const int, Proj, std::less<int>, Eigen::aligned_allocator<Proj> > ProjMap;
+  typedef std::map<const int, Proj, std::less<int>, Eigen::aligned_allocator<std::pair<const int, Proj>> > ProjMap;
 
   /// \brief Proj holds a projection measurement of a point onto a
   /// frame. They are a repository for the link between the frame and
@@ -73,6 +73,8 @@ namespace sba
       /// \brief Default constructor. Initializes to default values, 
       /// kp = <0 0 0> and ndi = <0>. Also sets the projection to be invalid.
       Proj();
+
+      //Proj & operator=(const Proj&) = delete;
       
       /// Node index, the camera node for this projection.
       int ndi;
@@ -87,7 +89,7 @@ namespace sba
       bool stereo;
       
       /// Calculates re-projection error and stores it in #err.
-     double calcErr(const Node &nd, const Point &pt, double huber = 0.0);
+      double calcErr(const Node &nd, const Point &pt, double huber = 0.0);
       
       /// \brief Get the correct squared norm of the error, depending on 
       /// whether the projection is monocular or stereo.
@@ -187,6 +189,8 @@ namespace sba
       
       /// Default constructor for Track.
       Track();
+
+      //Track & operator=(const Track&) = delete;
       
       /// \brief A map of all the projections of the point with camera index 
       /// as key, based off an STL map.

--- a/src/csparse.cpp
+++ b/src/csparse.cpp
@@ -109,11 +109,11 @@ namespace sba
     for (int i=0; i<(int)cols.size(); i++)
       {
         map<int,Matrix<double,6,6>, less<int>, 
-          aligned_allocator<Matrix<double,6,6> > > &col = cols[i];
+          aligned_allocator<std::pair<const int, Matrix<double,6,6>> > > &col = cols[i];
         if (col.size() > 0)
           {
             map<int,Matrix<double,6,6>, less<int>, 
-              aligned_allocator<Matrix<double,6,6> > >::iterator it;
+              aligned_allocator<std::pair<const int, Matrix<double,6,6>> > >::iterator it;
             for (it = col.begin(); it != col.end(); it++)
               it->second.setZero();
           }
@@ -131,10 +131,10 @@ namespace sba
   {
     // get column 
     map<int,Matrix<double,6,6>, less<int>, 
-      aligned_allocator<Matrix<double,6,6> > > &col = cols[jj];
+      aligned_allocator<std::pair<const int, Matrix<double,6,6>> > > &col = cols[jj];
     // find current matrix
     map<int,Matrix<double,6,6>, less<int>, 
-      aligned_allocator<Matrix<double,6,6> > >::iterator it;
+      aligned_allocator<std::pair<const int, Matrix<double,6,6>> > >::iterator it;
     it = col.find(ii);
     if (it == col.end())        // didn't find it
       col.insert(pair<int,Matrix<double,6,6> >(ii,m));
@@ -164,7 +164,7 @@ namespace sba
         for (int i=0; i<(int)cols.size(); i++)
           {
             map<int,Matrix<double,6,6>, less<int>, 
-              aligned_allocator<Matrix<double,6,6> > > &col = cols[i];
+              aligned_allocator<std::pair<const int, Matrix<double,6,6>> > > &col = cols[i];
             nnz += 36 * col.size(); // 6x6 matrix
           }
 
@@ -202,7 +202,7 @@ namespace sba
           {
             // column i entries
             map<int,Matrix<double,6,6>, less<int>, 
-              aligned_allocator<Matrix<double,6,6> > > &col = cols[i];
+              aligned_allocator<std::pair<const int, Matrix<double,6,6>> > > &col = cols[i];
 
             // do this for 6 columns
             for (int k=0; k<6; k++)
@@ -215,7 +215,7 @@ namespace sba
                   {
                     // map iterator
                     map<int,Matrix<double,6,6>, less<int>, 
-                      aligned_allocator<Matrix<double,6,6> > >::iterator it;
+                      aligned_allocator<std::pair<const int, Matrix<double,6,6>> > >::iterator it;
 
                     // iterate over block column entries
                     for (it = col.begin(); it != col.end(); it++)
@@ -250,7 +250,7 @@ namespace sba
        {
          // column i entries
          map<int,Matrix<double,6,6>, less<int>, 
-           aligned_allocator<Matrix<double,6,6> > > &col = cols[i];
+           aligned_allocator<std::pair<const int, Matrix<double,6,6>> > > &col = cols[i];
 
          // do this for 6 columns
          for (int k=0; k<6; k++)
@@ -260,7 +260,7 @@ namespace sba
                {
                  // map iterator
                  map<int,Matrix<double,6,6>, less<int>, 
-                   aligned_allocator<Matrix<double,6,6> > >::iterator it;
+                   aligned_allocator<std::pair<const int, Matrix<double,6,6>> > >::iterator it;
 
                  // iterate over block column entries
                  for (it = col.begin(); it != col.end(); it++)
@@ -432,7 +432,7 @@ namespace sba
 	  for (int i=0; i<(int)cols.size(); i++)
 	    {
 	      map<int,Matrix<double,3,3>, less<int>, 
-		aligned_allocator< Matrix <double,3,3> > > &col = cols[i];
+		aligned_allocator< std::pair<const int, Matrix <double,3,3>> > > &col = cols[i];
               col.clear();
             }
         asize = n;
@@ -448,11 +448,11 @@ namespace sba
 	for (int i=0; i<(int)cols.size(); i++)
 	  {
 	    map<int,Matrix<double,3,3>, less<int>, 
-	      aligned_allocator<Matrix<double,3,3> > > &col = cols[i];
+	      aligned_allocator<std::pair<const int, Matrix<double,3,3>> > > &col = cols[i];
             if (col.size() > 0)
 	      {
 		map<int,Matrix<double,3,3>, less<int>, 
-		  aligned_allocator<Matrix<double,3,3> > >::iterator it;
+		  aligned_allocator<std::pair<const int, Matrix<double,3,3>> > >::iterator it;
                 for (it = col.begin(); it != col.end(); it++)
 		  it->second.setZero();
               }
@@ -473,10 +473,10 @@ namespace sba
   {
     // get column 
     map<int,Matrix<double,3,3>, less<int>, 
-      aligned_allocator<Matrix<double,3,3> > > &col = cols[jj];
+      aligned_allocator<std::pair<const int, Matrix<double,3,3>> > > &col = cols[jj];
     // find current matrix
     map<int,Matrix<double,3,3>, less<int>, 
-      aligned_allocator<Matrix<double,3,3> > >::iterator it;
+      aligned_allocator<std::pair<const int, Matrix<double,3,3>> > >::iterator it;
     it = col.find(ii);
     if (it == col.end())        // didn't find it
       col.insert(pair<int,Matrix<double,3,3> >(ii,m));
@@ -517,7 +517,7 @@ namespace sba
         for (int i=0; i<(int)cols.size(); i++)
           {
             map<int,Matrix<double,3,3>, less<int>, 
-              aligned_allocator<Matrix<double,3,3> > > &col = cols[i];
+              aligned_allocator<std::pair<const int, Matrix<double,3,3>> > > &col = cols[i];
             nnz += 9 * col.size(); // 3x3 matrix
           }
 #ifdef SBA_CHOLMOD
@@ -554,7 +554,7 @@ namespace sba
           {
             // column i entries
             map<int,Matrix<double,3,3>, less<int>, 
-              aligned_allocator<Matrix<double,3,3> > > &col = cols[i];
+              aligned_allocator<std::pair<const int, Matrix<double,3,3>> > > &col = cols[i];
 
             // do this for 3 columns
             for (int k=0; k<3; k++)
@@ -567,7 +567,7 @@ namespace sba
                   {
                     // map iterator
                     map<int,Matrix<double,3,3>, less<int>, 
-                      aligned_allocator<Matrix<double,3,3> > >::iterator it;
+                      aligned_allocator<std::pair<const int, Matrix<double,3,3>> > >::iterator it;
 
                     // iterate over block column entries
                     for (it = col.begin(); it != col.end(); it++)
@@ -601,7 +601,7 @@ namespace sba
        {
          // column i entries
          map<int,Matrix<double,3,3>, less<int>, 
-           aligned_allocator<Matrix<double,3,3> > > &col = cols[i];
+           aligned_allocator<std::pair<const int, Matrix<double,3,3>> > > &col = cols[i];
 
          // do this for 3 columns
          for (int k=0; k<3; k++)
@@ -611,7 +611,7 @@ namespace sba
                {
                  // map iterator
                  map<int,Matrix<double,3,3>, less<int>, 
-                   aligned_allocator<Matrix<double,3,3> > >::iterator it;
+                   aligned_allocator<std::pair<const int, Matrix<double,3,3>> > >::iterator it;
 
                  // iterate over block column entries
                  for (it = col.begin(); it != col.end(); it++)

--- a/src/sba.cpp
+++ b/src/sba.cpp
@@ -119,7 +119,9 @@ namespace sba
         return true;
       return false;
     }
-    tracks[pi].projections[ci] = Proj(ci, q, stereo);
+    tracks[pi].projections.insert( pair<const int, Proj>(ci, Proj(ci, q, stereo)) ); 
+
+    //tracks[pi].projections[ci] = Proj(ci, q, stereo);
 
 #if 0
     /// NOTE
@@ -146,7 +148,8 @@ namespace sba
         return true;
       return false;
     }
-    tracks[pi].projections[ci] = Proj(ci, q);
+    tracks[pi].projections.insert( pair<const int, Proj>(ci, Proj(ci, q)) ); 
+    //tracks[pi].projections[ci] = Proj(ci, q);
     return true;
   }
   
@@ -161,7 +164,8 @@ namespace sba
         return true;
       return false;
     }
-    tracks[pi].projections[ci] = Proj(ci, q, true);
+    tracks[pi].projections.insert( pair<const int, Proj>(ci, Proj(ci, q, true)) ); 
+    //tracks[pi].projections[ci] = Proj(ci, q, true);
 
 #if 0
     /// NOTE
@@ -1624,7 +1628,8 @@ void SysSBA::setupSys(double sLambda)
                 int ci = prj.ndi;
                 
                 // Insert the projection into the original track
-                tr0[ci] = prj;
+                //tr0[ci] = prj;
+                tr0.insert( pair<const int, Proj>(ci, prj) ); 
               }
             tr1.clear();
           }

--- a/src/sba.cpp
+++ b/src/sba.cpp
@@ -119,9 +119,7 @@ namespace sba
         return true;
       return false;
     }
-    tracks[pi].projections.insert( pair<const int, Proj>(ci, Proj(ci, q, stereo)) ); 
-
-    //tracks[pi].projections[ci] = Proj(ci, q, stereo);
+    tracks[pi].projections[ci] = Proj(ci, q, stereo);
 
 #if 0
     /// NOTE
@@ -148,8 +146,7 @@ namespace sba
         return true;
       return false;
     }
-    tracks[pi].projections.insert( pair<const int, Proj>(ci, Proj(ci, q)) ); 
-    //tracks[pi].projections[ci] = Proj(ci, q);
+    tracks[pi].projections[ci] = Proj(ci, q);
     return true;
   }
   
@@ -164,8 +161,7 @@ namespace sba
         return true;
       return false;
     }
-    tracks[pi].projections.insert( pair<const int, Proj>(ci, Proj(ci, q, true)) ); 
-    //tracks[pi].projections[ci] = Proj(ci, q, true);
+    tracks[pi].projections[ci] = Proj(ci, q, true);
 
 #if 0
     /// NOTE
@@ -1628,8 +1624,7 @@ void SysSBA::setupSys(double sLambda)
                 int ci = prj.ndi;
                 
                 // Insert the projection into the original track
-                //tr0[ci] = prj;
-                tr0.insert( pair<const int, Proj>(ci, prj) ); 
+                tr0[ci] = prj;
               }
             tr1.clear();
           }


### PR DESCRIPTION
I think these changes are necessary with newer versions of GCC/Clang.

It still fails with the following error that I am not able to fix - any hints would be appreciated:

```
In file included from /Users/tobias/catkin_ws/src/sparse_bundle_adjustment/src/sba.cpp:39:
In file included from /Users/tobias/catkin_ws/src/sparse_bundle_adjustment/include/sparse_bundle_adjustment/sba.h:57:
In file included from /Users/tobias/catkin_ws/src/sparse_bundle_adjustment/include/sparse_bundle_adjustment/proj.h:12:
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:708:17: error: no viable overloaded '='
        __ref() = __v.__get_value();
        ~~~~~~~ ^ ~~~~~~~~~~~~~~~~~
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tree:1676:35: note: in instantiation of member function 'std::__1::__value_type<const int, sba::Proj>::operator=' requested here
                __cache->__value_ = *__first;
                                  ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/__tree:1606:9: note: in instantiation of function template specialization 'std::__1::__tree<std::__1::__value_type<const int, sba::Proj>, std::__1::__map_value_compare<const int, std::__1::__value_type<const int, sba::Proj>, std::__1::less<int>, true>, Eigen::aligned_allocator<std::__1::__value_type<const int, sba::Proj> > >::__assign_multi<std::__1::__tree_const_iterator<std::__1::__value_type<const int, sba::Proj>, std::__1::__tree_node<std::__1::__value_type<const int, sba::Proj>, void *> *, long> >' requested here
        __assign_multi(__t.begin(), __t.end());
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/map:1014:21: note: in instantiation of member function 'std::__1::__tree<std::__1::__value_type<const int, sba::Proj>, std::__1::__map_value_compare<const int, std::__1::__value_type<const int, sba::Proj>, std::__1::less<int>, true>, Eigen::aligned_allocator<std::__1::__value_type<const int, sba::Proj> > >::operator=' requested here
            __tree_ = __m.__tree_;
                    ^
/Users/tobias/catkin_ws/src/sparse_bundle_adjustment/include/sparse_bundle_adjustment/proj.h:184:9: note: in instantiation of member function 'std::__1::map<const int, sba::Proj, std::__1::less<int>, Eigen::aligned_allocator<std::__1::pair<const int, sba::Proj> > >::operator=' requested here
  class Track
        ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:315:29: note: candidate function (the implicit copy assignment operator) not viable: no known conversion from 'const pair<const std::__1::__value_type<const int, sba::Proj>::key_type, std::__1::__value_type<const int, sba::Proj>::mapped_type>' to 'const pair<const int &, sba::Proj &>' for 1st argument
struct _LIBCPP_TEMPLATE_VIS pair
                            ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:515:11: note: candidate function not viable: no known conversion from 'const std::__1::__value_type<const int, sba::Proj>::value_type' (aka 'const pair<const int, sba::Proj>') to 'const typename conditional<is_copy_assignable<first_type>::value && is_copy_assignable<second_type>::value, pair<const int &, Proj &>, __nat>::type' (aka 'const std::__1::__nat') for 1st argument
    pair& operator=(typename conditional<
          ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:528:11: note: candidate function not viable: no known conversion from 'const std::__1::__value_type<const int, sba::Proj>::value_type' (aka 'const pair<const int, sba::Proj>') to 'typename conditional<is_move_assignable<first_type>::value && is_move_assignable<second_type>::value, pair<const int &, Proj &>, __nat>::type' (aka 'std::__1::__nat') for 1st argument
    pair& operator=(typename conditional<
          ^
/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/../include/c++/v1/utility:352:62: note: candidate template ignored: disabled by 'enable_if' [with _Tuple = const std::__1::pair<const int, sba::Proj> &]
    using _EnableB _LIBCPP_NODEBUG_TYPE = typename enable_if<_Val, bool>::type;
```